### PR TITLE
Merge scraper and k3s manifests into master

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ The `DB_PATH` env var overrides the default DB location (used in k3s to point at
 
 ### Docker (cross-compile for x86 from Apple Silicon)
 ```bash
-docker buildx build --platform linux/amd64 -t txtxx56/ports_server:0.9 --push .
+docker buildx build --platform linux/amd64 -t txtxx56/ports_server:0.91 --push .
 ```
 
 The app runs on port **8001**.

--- a/README.md
+++ b/README.md
@@ -87,13 +87,13 @@ All columns are TEXT. The subheading hierarchy allows grouping ports in the fron
 Build for x86 from Apple Silicon:
 
 ```
-docker buildx build --platform linux/amd64 -t txtxx56/ports_server:0.9 --push .
+docker buildx build --platform linux/amd64 -t txtxx56/ports_server:0.91 --push .
 ```
 
 Run locally:
 
 ```
-docker run --rm -d -p 8001:8001 txtxx56/ports_server:0.9
+docker run --rm -d -p 8001:8001 txtxx56/ports_server:0.91
 ```
 
 ## Deployment

--- a/configuration.json
+++ b/configuration.json
@@ -84,7 +84,7 @@
     "product": "Explorer Postgres"
   },
   {
-    "url": "https://helpcenter.veeam.com/docs/backup/explorers/vemdb_used_ports.html",
+    "url": "https://helpcenter.veeam.com/docs/backup/explorers/vehana_used_ports.html",
     "product": "Explorer SAP HANA"
   },
   {

--- a/k3s/scraper-configmap.yaml
+++ b/k3s/scraper-configmap.yaml
@@ -93,7 +93,7 @@ data:
         "product": "Explorer Postgres"
       },
       {
-        "url": "https://helpcenter.veeam.com/docs/backup/explorers/vemdb_used_ports.html",
+        "url": "https://helpcenter.veeam.com/docs/backup/explorers/vehana_used_ports.html",
         "product": "Explorer SAP HANA"
       },
       {

--- a/scrape_ports.py
+++ b/scrape_ports.py
@@ -77,6 +77,10 @@ def scrape_product(product: str, url: str) -> list[pd.DataFrame]:
     current_subheading_l3 = ""
     product_dfs = []
 
+    if soup.body is None:
+        log.warning("No <body> tag found while scraping product '%s' from %s", product, url)
+        return product_dfs
+
     for element in soup.body.find_all(["span", "table"]):
         if element.name == "span" and "class" in element.attrs:
             classes = element.get("class", [])


### PR DESCRIPTION
## Summary
- Adds standalone scraper (`scrape_ports.py`) with `CONFIG_PATH` env var support for reading configuration from a mounted ConfigMap
- Adds full k3s deployment manifests (backend, frontend, scraper CronJob, PVC, ingress, TLS)
- Externalizes scraper config via ConfigMap, bumps image tag to 0.91
- Updates `configuration.json` with v13 URLs and v12.3 archive URLs
- Adds `CLAUDE.md` and updates `README.md`

## Cleanup
After merging, delete the following stale branches:
- `update110226`
- `add-Section`
- `updated-database`