### PR TITLE
Add LLM-friendly API endpoints for MCP server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,5 +79,9 @@ Internet → magicports.veeambp.com (TLS via Let's Encrypt + cert-manager)
 | POST | `/target` | Target services for a source/product |
 | POST | `/allTarget` | All ports for source/product/subheading |
 | POST | `/ports` | Ports for a specific source/target/product |
+| GET | `/products/{name}/ports` | All ports for a product |
+| GET | `/products/{name}/subheadings` | Distinct subheadings for a product |
+| GET | `/search?q=` | Free-text search across all fields |
+| GET | `/search/port/{port}` | Find entries by port number |
 | POST | `/generateExcelWithUrl` | Generate Excel file from port data |
 | GET | `/download/{filename}` | Download generated Excel file |

--- a/ports_server.py
+++ b/ports_server.py
@@ -5,7 +5,7 @@ import pandas as pd
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import FileResponse
 from fastapi.middleware.cors import CORSMiddleware
-from sqlalchemy import create_engine, MetaData, Table, select, distinct
+from sqlalchemy import create_engine, MetaData, Table, select, distinct, or_
 
 # from pydantic import BaseModel
 from typing import List
@@ -151,6 +151,60 @@ async def get_ports(request: PortRequest):
     records = df.to_dict("records")
     response_models = [PortResponse(**record) for record in records]
     return response_models
+
+
+@app.get("/products/{name}/ports", response_model=List[PortResponse])
+async def get_product_ports(name: str):
+    stmt = (
+        select(all_ports)
+        .where(all_ports.c.product == name)
+        .order_by(
+            all_ports.c.subheading,
+            all_ports.c.subheadingL2,
+            all_ports.c.subheadingL3,
+        )
+    )
+    df = pd.read_sql(stmt, engine)
+    records = df.to_dict("records")
+    return [PortResponse(**record) for record in records]
+
+
+@app.get("/products/{name}/subheadings")
+async def get_product_subheadings(name: str) -> List[str]:
+    stmt = (
+        select(distinct(all_ports.c.subheading))
+        .where(all_ports.c.product == name)
+        .order_by(all_ports.c.subheading)
+    )
+    with engine.connect() as conn:
+        result = conn.execute(stmt)
+        return [row[0] for row in result]
+
+
+@app.get("/search", response_model=List[PortResponse])
+async def search_ports(q: str):
+    pattern = f"%{q}%"
+    stmt = select(all_ports).where(
+        or_(
+            all_ports.c.sourceService.like(pattern),
+            all_ports.c.targetService.like(pattern),
+            all_ports.c.description.like(pattern),
+            all_ports.c.port.like(pattern),
+            all_ports.c.subheading.like(pattern),
+            all_ports.c.product.like(pattern),
+        )
+    )
+    df = pd.read_sql(stmt, engine)
+    records = df.to_dict("records")
+    return [PortResponse(**record) for record in records]
+
+
+@app.get("/search/port/{port}", response_model=List[PortResponse])
+async def search_by_port(port: str):
+    stmt = select(all_ports).where(all_ports.c.port.like(f"%{port}%"))
+    df = pd.read_sql(stmt, engine)
+    records = df.to_dict("records")
+    return [PortResponse(**record) for record in records]
 
 
 @app.post("/generateExcelWithUrl")


### PR DESCRIPTION
## Summary
- Adds `GET /products/{name}/ports` — all ports for a product in one call
- Adds `GET /products/{name}/subheadings` — distinct subheadings for a product
- Adds `GET /search?q=` — free-text search across all fields
- Adds `GET /search/port/{port}` — find entries by port number
- Updates CLAUDE.md API endpoints table

These endpoints support the upcoming MCP server (`veeam-ports-mcp`) by providing broader query capabilities that LLMs need beyond the existing drill-down flow.

## Test plan
- [x] Tested all 4 endpoints via FastAPI TestClient
- [ ] Deploy and verify against live database

🤖 Generated with [Claude Code](https://claude.com/claude-code)