### PR TITLE
API enhancements: filtering, services, warnings, formats, and bug fixes

### DIFF
--- a/ROLLOUT.md
+++ b/ROLLOUT.md
@@ -1,0 +1,112 @@
+# Rollout Guide: API Enhancements (v1.0)
+
+Deployment steps for the `feature/api-enhancements` branch changes.
+PR: https://github.com/shapedthought/ports_server/pull/30
+
+## What changed
+
+- Subsection/port exclusion filtering on topology and app-import endpoints
+- Service discovery endpoint (`GET /products/{name}/services`)
+- Fuzzy-match warnings for unresolved service names
+- CSV and markdown output formats
+- ESXi synonym merge at graph build time and runtime
+- App-import now populates inbound fields, normalizes port strings, writes a top-level array
+
+## Prerequisites
+
+- `kubectl` configured for the k3s cluster
+- Docker with `buildx` for cross-compilation (if building from Apple Silicon)
+- The `veeam-ports-enrichment` secret already exists with a valid `ANTHROPIC_API_KEY`
+
+## Rollout order
+
+### 1. Merge the PR
+
+```bash
+gh pr merge 30 --squash
+git checkout master && git pull
+```
+
+### 2. Build and push the Docker image
+
+From the repo root on Apple Silicon:
+
+```bash
+docker buildx build --platform linux/amd64 \
+  -t txtxx56/ports_server:1.0 --push .
+```
+
+This image includes all dependencies (`fastembed`, `sqlite-vec`, `anthropic`) and pre-downloads the embedding model.
+
+### 3. Apply updated k3s manifests
+
+The backend deployment and scraper cronjob manifests have been updated to use `txtxx56/ports_server:1.0`.
+
+```bash
+# Update backend deployment (triggers rolling restart)
+kubectl apply -f k3s/ports-backend-deployment.yaml
+
+# Update scraper cronjob (next scheduled run uses new image)
+kubectl apply -f k3s/scraper-cronjob.yaml
+```
+
+### 4. Trigger a manual scrape
+
+The new image includes `graph_builder.py` with synonym normalization. A re-scrape is required to rebuild the knowledge graph with merged synonyms.
+
+```bash
+kubectl create job --from=cronjob/ports-scraper manual-scrape-v1
+```
+
+Monitor progress:
+
+```bash
+kubectl logs -f job/manual-scrape-v1
+```
+
+The scraper runs the full pipeline: scrape -> enrich (Anthropic API) -> build graph -> build embeddings. Expect ~5-10 minutes depending on API latency.
+
+### 5. Verify the deployment
+
+```bash
+# Health check
+curl https://magicports.veeambp.com/ports_server/health
+
+# Service discovery
+curl https://magicports.veeambp.com/ports_server/products/VBR%20v13/services | head
+
+# App-import with CDP exclusion (should include 443 to ESXi)
+curl -s -X POST https://magicports.veeambp.com/ports_server/products/VBR%20v13/app-import \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "servers": [
+      {"name": "VBR", "services": ["Backup server"]},
+      {"name": "ESXi", "services": ["ESXi host"]}
+    ],
+    "options": {"exclude_subsections": ["CDP Components"]}
+  }'
+```
+
+### 6. Verify the scrape completed
+
+```bash
+kubectl get jobs | grep manual-scrape-v1
+```
+
+Once the scrape job completes, the backend automatically picks up the new DB (atomic swap via `os.replace`). No backend restart needed after scraping.
+
+## Rollback
+
+If issues arise, revert to the previous image:
+
+```bash
+kubectl set image deployment/ports-backend-deployment \
+  ports-backend=txtxx56/ports_server:0.92
+```
+
+## Notes
+
+- **PVC**: 500Mi, current DB is ~2MB (well within limits even with embeddings)
+- **Scraper CronJob**: runs weekly (Monday 06:00 UTC), uses the same image as the backend
+- **Anthropic secret**: `veeam-ports-enrichment` must exist with `ANTHROPIC_API_KEY` for enrichment to succeed
+- **MCP server** (`veeam-ports-mcp`): changes already pushed to `main`. Claude Desktop picks up changes on restart via `uv run --directory` — no separate deployment needed

--- a/graph_builder.py
+++ b/graph_builder.py
@@ -11,23 +11,9 @@ import logging
 import sqlite3
 import time
 
+from synonyms import SYNONYM_CANONICAL as _SYNONYM_CANONICAL
+
 log = logging.getLogger(__name__)
-
-# ---------------------------------------------------------------------------
-# Synonym normalization — merge equivalent canonical names at graph build time.
-# Each set groups canonical names that refer to the same logical component.
-# The alphabetically-first name becomes the canonical representative.
-# Must stay in sync with ROLE_SYNONYM_GROUPS in ports_server.py.
-# ---------------------------------------------------------------------------
-ROLE_SYNONYM_GROUPS: list[set[str]] = [
-    {"esxi server", "esxi host"},
-]
-
-_SYNONYM_CANONICAL: dict[str, str] = {}
-for _group in ROLE_SYNONYM_GROUPS:
-    _representative = min(_group)
-    for _name in _group:
-        _SYNONYM_CANONICAL[_name] = _representative
 
 
 def _normalize_canonical(name: str) -> str:

--- a/graph_builder.py
+++ b/graph_builder.py
@@ -13,6 +13,27 @@ import time
 
 log = logging.getLogger(__name__)
 
+# ---------------------------------------------------------------------------
+# Synonym normalization — merge equivalent canonical names at graph build time.
+# Each set groups canonical names that refer to the same logical component.
+# The alphabetically-first name becomes the canonical representative.
+# Must stay in sync with ROLE_SYNONYM_GROUPS in ports_server.py.
+# ---------------------------------------------------------------------------
+ROLE_SYNONYM_GROUPS: list[set[str]] = [
+    {"esxi server", "esxi host"},
+]
+
+_SYNONYM_CANONICAL: dict[str, str] = {}
+for _group in ROLE_SYNONYM_GROUPS:
+    _representative = min(_group)
+    for _name in _group:
+        _SYNONYM_CANONICAL[_name] = _representative
+
+
+def _normalize_canonical(name: str) -> str:
+    """Map synonym canonical names to a single representative."""
+    return _SYNONYM_CANONICAL.get(name.lower(), name)
+
 
 def build_graph(conn: sqlite3.Connection) -> None:
     """Build the knowledge graph from enriched_ports data.
@@ -103,8 +124,10 @@ def _extract_components(cur: sqlite3.Cursor) -> dict[tuple, int]:
     target_rows = cur.fetchall()
 
     # Deduplicate: keep first original_name per (product, canonical, os, hyp, storage)
+    # Normalize synonyms so e.g. "esxi server" and "esxi host" merge into one component.
     seen: dict[tuple, str] = {}  # key -> first original_name
     for product, canonical, os_val, hyp, storage, original in source_rows + target_rows:
+        canonical = _normalize_canonical(canonical)
         key = (product, canonical, _normalize_null(os_val), _normalize_null(hyp), _normalize_null(storage))
         if key not in seen:
             seen[key] = original
@@ -153,6 +176,8 @@ def _extract_connections(cur: sqlite3.Cursor, component_lookup: dict[tuple, int]
          t_canon, t_os, t_hyp, t_storage,
          port, protocol, description) = row
 
+        s_canon = _normalize_canonical(s_canon)
+        t_canon = _normalize_canonical(t_canon)
         source_key = (product, s_canon, _normalize_null(s_os), _normalize_null(s_hyp), _normalize_null(s_storage))
         target_key = (product, t_canon, _normalize_null(t_os), _normalize_null(t_hyp), _normalize_null(t_storage))
 

--- a/k3s/ports-backend-deployment.yaml
+++ b/k3s/ports-backend-deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: ports-backend
-        image: txtxx56/ports_server:0.92
+        image: txtxx56/ports_server:1.0
         ports:
         - containerPort: 8001
         env:

--- a/k3s/scraper-cronjob.yaml
+++ b/k3s/scraper-cronjob.yaml
@@ -15,7 +15,7 @@ spec:
         spec:
           containers:
           - name: scraper
-            image: txtxx56/ports_server:0.92
+            image: txtxx56/ports_server:1.0
             command: ["python", "scrape_ports.py"]
             env:
             - name: DB_PATH

--- a/models.py
+++ b/models.py
@@ -69,6 +69,8 @@ class TopologyServer(BaseModel):
 class TopologyOptions(BaseModel):
     include_loopback: bool = False
     include_unresolved: bool = False
+    exclude_subsections: list[str] = Field(default_factory=list)
+    exclude_ports: list[str] = Field(default_factory=list)
 
 
 class TopologyRequest(BaseModel):
@@ -105,11 +107,18 @@ class ServerTopology(BaseModel):
     mappedPortsByProtocolInbound: list[MappedPortByProtocol]
 
 
+class UnresolvedServiceWarning(BaseModel):
+    service: str
+    server: str
+    suggestions: list[str] = Field(default_factory=list)
+
+
 class TopologyMetadata(BaseModel):
     total_entries_matched: int
     total_entries_skipped: int
     enrichment_version: str | None = None
     unresolved_services: list[str] = Field(default_factory=list)
+    warnings: list[UnresolvedServiceWarning] = Field(default_factory=list)
 
 
 class TopologyResponse(BaseModel):
@@ -154,6 +163,22 @@ class AppImportServer(BaseModel):
     allOutboundPortsUdp: list[str]
     mappedPortsByProtocol: list[AppImportPortByProtocol]
     mappedPortsByProtocolInbound: list[AppImportPortByProtocol]
+
+
+class AppImportResponse(BaseModel):
+    servers: list[AppImportServer]
+    warnings: list[UnresolvedServiceWarning] = Field(default_factory=list)
+
+
+# --- Service discovery models ---
+
+
+class ServiceInfo(BaseModel):
+    canonical: str
+    original_names: list[str]
+    os: list[str] = Field(default_factory=list)
+    hypervisor: list[str] = Field(default_factory=list)
+    storage_type: list[str] = Field(default_factory=list)
 
 
 # --- Semantic search models (Phase 3) ---

--- a/ports_server.py
+++ b/ports_server.py
@@ -599,7 +599,7 @@ def _load_components(conn, product: str) -> dict:
         by_original[orig].append(cid)
         by_original_lower[orig.lower()].append(cid)
         by_key[(canonical, os_val, hyp, storage)] = cid
-        by_canonical[canonical].append(cid)
+        by_canonical[canonical.lower()].append(cid)
 
     return {
         "by_original": by_original,
@@ -734,7 +734,7 @@ def _expand_synonyms(component_ids: list[int], components: dict) -> list[int]:
         comp = components["all"].get(cid)
         if not comp:
             continue
-        canonical = comp["canonical"]
+        canonical = comp["canonical"].lower()
         for synonym in _SYNONYM_INDEX.get(canonical, set()):
             if synonym in components["by_canonical"]:
                 expanded.update(components["by_canonical"][synonym])

--- a/ports_server.py
+++ b/ports_server.py
@@ -1,3 +1,6 @@
+import csv
+import difflib
+import io
 import json
 import logging
 import os
@@ -15,9 +18,11 @@ from sqlalchemy import create_engine, event, MetaData, Table, select, distinct, 
 from sqlalchemy.exc import OperationalError
 
 from typing import List
+from fastapi.responses import Response
 from models import (
     AppImportMappedPort,
     AppImportPortByProtocol,
+    AppImportResponse,
     AppImportServer,
     EnrichedPortResponse,
     MappedPort,
@@ -27,11 +32,13 @@ from models import (
     SemanticSearchResponse,
     SemanticSearchResult,
     ServerTopology,
+    ServiceInfo,
     ServiceMeta,
     TargetRequest,
     TopologyMetadata,
     TopologyRequest,
     TopologyResponse,
+    UnresolvedServiceWarning,
     PortRequest,
     SourceRequest,
     SourceResponse,
@@ -247,6 +254,54 @@ async def get_product_subheadings(name: str) -> List[str]:
         return [row[0] for row in result]
 
 
+@app.get("/products/{name}/services", response_model=List[ServiceInfo])
+async def list_services(name: str):
+    """List all canonical service roles for a product with their variants."""
+    try:
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text("SELECT canonical, os, hypervisor, storage_type, original_name "
+                     "FROM components WHERE product = :p ORDER BY canonical"),
+                {"p": name},
+            ).mappings().all()
+    except OperationalError:
+        raise HTTPException(status_code=404, detail="Graph tables not found.")
+
+    if not rows:
+        raise HTTPException(status_code=404, detail=f"No services found for product '{name}'.")
+
+    grouped: dict[str, dict] = {}
+    for row in rows:
+        canonical = row["canonical"]
+        if canonical not in grouped:
+            grouped[canonical] = {
+                "original_names": set(),
+                "os": set(),
+                "hypervisor": set(),
+                "storage_type": set(),
+            }
+        g = grouped[canonical]
+        if row["original_name"]:
+            g["original_names"].add(row["original_name"])
+        if row["os"]:
+            g["os"].add(row["os"])
+        if row["hypervisor"]:
+            g["hypervisor"].add(row["hypervisor"])
+        if row["storage_type"]:
+            g["storage_type"].add(row["storage_type"])
+
+    return [
+        ServiceInfo(
+            canonical=canonical,
+            original_names=sorted(data["original_names"]),
+            os=sorted(data["os"]),
+            hypervisor=sorted(data["hypervisor"]),
+            storage_type=sorted(data["storage_type"]),
+        )
+        for canonical, data in sorted(grouped.items())
+    ]
+
+
 def _parse_roles(raw: str) -> list[str]:
     """Parse a JSON-encoded list of roles, returning [] on failure."""
     try:
@@ -320,6 +375,8 @@ def _resolve_topology_graph(name: str, request: TopologyRequest):
     Returns (components, server_component_sets, component_to_servers,
              matched_connections, all_connections, enrichment_version, unresolved).
     """
+    options = request.options
+
     try:
         with engine.connect() as conn:
             components = _load_components(conn, name)
@@ -333,6 +390,13 @@ def _resolve_topology_graph(name: str, request: TopologyRequest):
             enrichment_lookup, enrichment_lookup_lower = _load_enrichment_lookup(conn, name)
             all_connections = _load_connections(conn, name)
             enrichment_version = _get_enrichment_version(conn, name)
+
+            # Build subsection exclusion set if requested
+            excluded_conn_keys: set[tuple] = set()
+            if options.exclude_subsections:
+                excluded_conn_keys = _load_excluded_connections(
+                    conn, name, options.exclude_subsections, components,
+                )
     except OperationalError:
         raise HTTPException(
             status_code=404,
@@ -341,6 +405,10 @@ def _resolve_topology_graph(name: str, request: TopologyRequest):
 
     server_component_sets: dict[str, set[int]] = {}
     unresolved: list[str] = []
+    warnings: list[UnresolvedServiceWarning] = []
+
+    # Build candidate list for fuzzy matching once
+    fuzzy_candidates = list(components["by_original"].keys()) + list(components["by_canonical"].keys())
 
     for server in request.servers:
         component_ids: set[int] = set()
@@ -350,7 +418,12 @@ def _resolve_topology_graph(name: str, request: TopologyRequest):
                 component_ids.update(resolved)
             else:
                 unresolved.append(service_name)
-                log.warning("Could not resolve service '%s' for server '%s'", service_name, server.name)
+                suggestions = difflib.get_close_matches(service_name, fuzzy_candidates, n=3, cutoff=0.6)
+                warnings.append(UnresolvedServiceWarning(
+                    service=service_name, server=server.name, suggestions=suggestions,
+                ))
+                log.warning("Could not resolve service '%s' for server '%s' (suggestions: %s)",
+                            service_name, server.name, suggestions)
         server_component_sets[server.name] = component_ids
         log.info("Server '%s': resolved %d component(s) from %d service(s)", server.name, len(component_ids), len(server.services))
 
@@ -396,11 +469,20 @@ def _resolve_topology_graph(name: str, request: TopologyRequest):
         generic = variants.get(component_id)
         return generic is not None and generic in all_component_ids
 
+    exclude_ports_set = set(options.exclude_ports)
+
     matched_connections = []
     for conn_row in all_connections:
         src_id, tgt_id = conn_row["source_component_id"], conn_row["target_component_id"]
-        if _matches(src_id) and _matches(tgt_id):
-            matched_connections.append(conn_row)
+        if not (_matches(src_id) and _matches(tgt_id)):
+            continue
+        # Apply port exclusion filter
+        if conn_row["port"] in exclude_ports_set:
+            continue
+        # Apply subsection exclusion filter
+        if excluded_conn_keys and (src_id, tgt_id, conn_row["port"], conn_row["protocol"]) in excluded_conn_keys:
+            continue
+        matched_connections.append(conn_row)
 
     # Augment server component sets with the specific variant IDs that were
     # actually used in matched connections (targeted, not blanket expansion).
@@ -415,14 +497,14 @@ def _resolve_topology_graph(name: str, request: TopologyRequest):
                     all_component_ids.add(cid)
 
     return (components, server_component_sets, component_to_servers,
-            matched_connections, all_connections, enrichment_version, unresolved)
+            matched_connections, all_connections, enrichment_version, unresolved, warnings)
 
 
 @app.post("/products/{name}/topology", response_model=TopologyResponse)
-async def generate_topology(name: str, request: TopologyRequest):
+async def generate_topology(name: str, request: TopologyRequest, format: str = "json"):
     """Resolve server topology via knowledge graph traversal."""
     (components, server_component_sets, component_to_servers,
-     matched_connections, all_connections, enrichment_version, unresolved) = \
+     matched_connections, all_connections, enrichment_version, unresolved, warnings) = \
         _resolve_topology_graph(name, request)
 
     server_topologies = []
@@ -436,6 +518,16 @@ async def generate_topology(name: str, request: TopologyRequest):
         )
         server_topologies.append(topology)
 
+    log.info(
+        "Topology for '%s': %d connections matched, %d skipped, %d unresolved services",
+        name, len(matched_connections), len(all_connections) - len(matched_connections), len(unresolved),
+    )
+
+    if format == "csv":
+        return Response(content=_render_topology_csv(server_topologies), media_type="text/csv")
+    if format == "markdown":
+        return Response(content=_render_topology_markdown(server_topologies), media_type="text/markdown")
+
     total_product_connections = len(all_connections)
     total_matched = len(matched_connections)
     meta = TopologyMetadata(
@@ -443,21 +535,17 @@ async def generate_topology(name: str, request: TopologyRequest):
         total_entries_skipped=total_product_connections - total_matched,
         enrichment_version=enrichment_version,
         unresolved_services=unresolved if request.options.include_unresolved else [],
-    )
-
-    log.info(
-        "Topology for '%s': %d connections matched, %d skipped, %d unresolved services",
-        name, total_matched, total_product_connections - total_matched, len(unresolved),
+        warnings=warnings,
     )
 
     return TopologyResponse(product=name, servers=server_topologies, metadata=meta)
 
 
-@app.post("/products/{name}/app-import", response_model=List[AppImportServer])
-async def generate_app_import(name: str, request: TopologyRequest):
+@app.post("/products/{name}/app-import", response_model=AppImportResponse)
+async def generate_app_import(name: str, request: TopologyRequest, format: str = "json"):
     """Generate port mapping entries for Magic Ports frontend import."""
     (components, server_component_sets, component_to_servers,
-     matched_connections, all_connections, _, _) = \
+     matched_connections, all_connections, _, _, warnings) = \
         _resolve_topology_graph(name, request)
 
     servers = []
@@ -478,7 +566,12 @@ async def generate_app_import(name: str, request: TopologyRequest):
         name, len(servers), len(matched_connections),
     )
 
-    return servers
+    if format == "csv":
+        return Response(content=_render_app_import_csv(servers), media_type="text/csv")
+    if format == "markdown":
+        return Response(content=_render_app_import_markdown(servers), media_type="text/markdown")
+
+    return AppImportResponse(servers=servers, warnings=warnings)
 
 
 def _load_components(conn, product: str) -> dict:
@@ -565,6 +658,46 @@ def _load_enrichment_lookup(conn, product: str) -> tuple[dict[str, tuple], dict[
             if lower_key not in lower_lookup:
                 lower_lookup[lower_key] = value
     return lookup, lower_lookup
+
+
+def _load_excluded_connections(
+    conn, product: str, exclude_subsections: list[str], components: dict,
+) -> set[tuple]:
+    """Build a set of (src_id, tgt_id, port, protocol) tuples to exclude.
+
+    Queries enriched_ports for rows matching excluded subsections, then maps
+    service names to component IDs.
+    """
+    placeholders = ", ".join(f":s{i}" for i in range(len(exclude_subsections)))
+    params = {"p": product}
+    params.update({f"s{i}": s for i, s in enumerate(exclude_subsections)})
+
+    rows = conn.execute(
+        text(f"""
+            SELECT sourceService, targetService, port, protocol,
+                   source_canonical, source_os, source_hypervisor, source_storage_type,
+                   target_canonical, target_os, target_hypervisor, target_storage_type
+            FROM enriched_ports
+            WHERE product = :p AND (subheading IN ({placeholders})
+                                    OR subheadingL2 IN ({placeholders})
+                                    OR subheadingL3 IN ({placeholders}))
+        """),
+        params,
+    ).fetchall()
+
+    excluded: set[tuple] = set()
+    by_key = components["by_key"]
+
+    for row in rows:
+        src_key = (row[4], row[5] or None, row[6] or None, row[7] or None)
+        tgt_key = (row[8], row[9] or None, row[10] or None, row[11] or None)
+        src_id = by_key.get(src_key)
+        tgt_id = by_key.get(tgt_key)
+        if src_id is not None and tgt_id is not None:
+            excluded.add((src_id, tgt_id, row[2], row[3]))
+
+    log.info("Exclusion filter: %d connection keys from %d enriched rows", len(excluded), len(rows))
+    return excluded
 
 
 def _load_connections(conn, product: str) -> list[dict]:
@@ -759,6 +892,68 @@ def _split_protocols(protocol: str) -> list[str]:
     """Split a protocol string like 'TCP, UDP' into individual protocols."""
     parts = [p.strip().upper() for p in protocol.replace("/", ",").split(",")]
     return [p for p in parts if p in ("TCP", "UDP")]
+
+
+_CSV_COLUMNS = ["Source Server", "Target Server", "Source Service", "Target Service",
+                "Port", "Protocol", "Description"]
+
+
+def _render_topology_csv(servers: list[ServerTopology]) -> str:
+    """Render topology results as CSV."""
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(_CSV_COLUMNS)
+    for srv in servers:
+        for mp in srv.mappedPorts:
+            writer.writerow([
+                srv.sourceServer, mp.server, "", "",
+                mp.port, mp.protocol, mp.description,
+            ])
+    return buf.getvalue()
+
+
+def _render_app_import_csv(servers: list[AppImportServer]) -> str:
+    """Render app-import results as CSV."""
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(_CSV_COLUMNS)
+    for srv in servers:
+        for mp in srv.mappedPorts:
+            writer.writerow([
+                mp.sourceServerName, mp.targetServerName,
+                mp.sourceService, mp.targetService,
+                mp.port, mp.protocol, mp.description,
+            ])
+    return buf.getvalue()
+
+
+def _render_topology_markdown(servers: list[ServerTopology]) -> str:
+    """Render topology results as a markdown table."""
+    lines = [
+        "| Source Server | Target Server | Port | Protocol | Direction | Description |",
+        "|---|---|---|---|---|---|",
+    ]
+    for srv in servers:
+        for mp in srv.mappedPorts:
+            desc = mp.description.replace("|", "\\|")[:80]
+            lines.append(f"| {srv.sourceServer} | {mp.server} | {mp.port} | {mp.protocol} | {mp.direction} | {desc} |")
+    return "\n".join(lines)
+
+
+def _render_app_import_markdown(servers: list[AppImportServer]) -> str:
+    """Render app-import results as a markdown table."""
+    lines = [
+        "| Source Server | Target Server | Source Service | Target Service | Port | Protocol | Description |",
+        "|---|---|---|---|---|---|---|",
+    ]
+    for srv in servers:
+        for mp in srv.mappedPorts:
+            desc = mp.description.replace("|", "\\|")[:80]
+            lines.append(
+                f"| {mp.sourceServerName} | {mp.targetServerName} | {mp.sourceService} "
+                f"| {mp.targetService} | {mp.port} | {mp.protocol} | {desc} |"
+            )
+    return "\n".join(lines)
 
 
 def _build_app_import_server(

--- a/ports_server.py
+++ b/ports_server.py
@@ -44,24 +44,9 @@ from models import (
     SourceResponse,
 )
 
+from synonyms import SYNONYM_INDEX as _SYNONYM_INDEX, SYNONYM_CANONICAL as _SYNONYM_CANONICAL
+
 log = logging.getLogger(__name__)
-
-# ---------------------------------------------------------------------------
-# Role synonym resolution
-# ---------------------------------------------------------------------------
-# Each set groups canonical names that refer to the same logical component.
-# All values must be lowercase.
-ROLE_SYNONYM_GROUPS: list[set[str]] = [
-    {"esxi server", "esxi host"},
-]
-
-_SYNONYM_INDEX: dict[str, set[str]] = {}
-_SYNONYM_CANONICAL: dict[str, str] = {}  # maps each name → deterministic representative
-for _group in ROLE_SYNONYM_GROUPS:
-    _representative = min(_group)  # alphabetically first for stability
-    for _name in _group:
-        _SYNONYM_INDEX[_name] = _group - {_name}
-        _SYNONYM_CANONICAL[_name] = _representative
 
 app = FastAPI()
 
@@ -500,7 +485,11 @@ def _resolve_topology_graph(name: str, request: TopologyRequest):
             matched_connections, all_connections, enrichment_version, unresolved, warnings)
 
 
-@app.post("/products/{name}/topology", response_model=TopologyResponse)
+@app.post(
+    "/products/{name}/topology",
+    response_model=TopologyResponse,
+    responses={200: {"content": {"text/csv": {}, "text/markdown": {}}}},
+)
 async def generate_topology(name: str, request: TopologyRequest, format: str = "json"):
     """Resolve server topology via knowledge graph traversal."""
     (components, server_component_sets, component_to_servers,
@@ -541,7 +530,11 @@ async def generate_topology(name: str, request: TopologyRequest, format: str = "
     return TopologyResponse(product=name, servers=server_topologies, metadata=meta)
 
 
-@app.post("/products/{name}/app-import", response_model=AppImportResponse)
+@app.post(
+    "/products/{name}/app-import",
+    response_model=AppImportResponse,
+    responses={200: {"content": {"text/csv": {}, "text/markdown": {}}}},
+)
 async def generate_app_import(name: str, request: TopologyRequest, format: str = "json"):
     """Generate port mapping entries for Magic Ports frontend import."""
     (components, server_component_sets, component_to_servers,
@@ -1078,7 +1071,8 @@ def _build_app_import_server(
     outbound_tcp: set[str] = set()
     outbound_udp: set[str] = set()
     outbound_by_sp: dict[tuple, set[str]] = defaultdict(set)
-    # Track target service per (serverName, port, protocol) for the service field
+    # Track target service per (serverName, port, protocol) for the service field.
+    # Use setdefault to keep the first service seen per key (stable, not overwritten).
     outbound_service: dict[tuple, str] = {}
 
     for mp in mapped_ports:
@@ -1090,7 +1084,7 @@ def _build_app_import_server(
                 elif proto == "UDP":
                     outbound_udp.add(ip)
                 outbound_by_sp[(mp.targetServerName, proto)].add(ip)
-                outbound_service[(mp.targetServerName, proto, ip)] = mp.targetService
+                outbound_service.setdefault((mp.targetServerName, proto, ip), mp.targetService)
 
     mapped_by_protocol = []
     idx = 0
@@ -1141,7 +1135,7 @@ def _build_app_import_server(
                     elif proto == "UDP":
                         inbound_udp.add(ip)
                     inbound_by_sp[(peer_server, proto)].add(ip)
-                    inbound_service[(peer_server, proto, ip)] = source_service
+                    inbound_service.setdefault((peer_server, proto, ip), source_service)
 
     mapped_by_protocol_inbound = []
     idx = 0
@@ -1154,15 +1148,18 @@ def _build_app_import_server(
             ))
             idx += 1
 
-    peer_servers = set(mp.targetServerName for mp in mapped_ports
-                       if mp.targetServerName != server_name)
+    # Count all distinct peer servers (both outbound targets and inbound sources)
+    outbound_peers = set(mp.targetServerName for mp in mapped_ports
+                         if mp.targetServerName != server_name)
+    inbound_peers = set(key[0] for key in inbound_seen if key[0] != server_name)
+    all_peers = outbound_peers | inbound_peers
 
     return AppImportServer(
         id=server_id,
         sourceServer=server_name,
         totalMappedPorts=len(mapped_ports),
         totalMappedInboundPorts=len(inbound_seen),
-        totalMappedServers=len(peer_servers),
+        totalMappedServers=len(all_peers),
         mappedPorts=mapped_ports,
         allInboundPortsTcp=_normalize_port_entries(inbound_tcp),
         allOutboundPortsTcp=_normalize_port_entries(outbound_tcp),

--- a/ports_server.py
+++ b/ports_server.py
@@ -666,12 +666,14 @@ def _load_excluded_connections(
     """Build a set of (src_id, tgt_id, port, protocol) tuples to exclude.
 
     Queries enriched_ports for rows matching excluded subsections, then maps
-    service names to component IDs.
+    service names to component IDs.  Connections that also appear in
+    non-excluded subsections are kept (not excluded).
     """
     placeholders = ", ".join(f":s{i}" for i in range(len(exclude_subsections)))
     params = {"p": product}
     params.update({f"s{i}": s for i, s in enumerate(exclude_subsections)})
 
+    # Rows IN the excluded subsections
     rows = conn.execute(
         text(f"""
             SELECT sourceService, targetService, port, protocol,
@@ -685,18 +687,55 @@ def _load_excluded_connections(
         params,
     ).fetchall()
 
-    excluded: set[tuple] = set()
+    # Rows NOT in the excluded subsections (same port/proto may appear elsewhere)
+    retained_rows = conn.execute(
+        text(f"""
+            SELECT source_canonical, source_os, source_hypervisor, source_storage_type,
+                   target_canonical, target_os, target_hypervisor, target_storage_type,
+                   port, protocol
+            FROM enriched_ports
+            WHERE product = :p AND NOT (subheading IN ({placeholders})
+                                        OR subheadingL2 IN ({placeholders})
+                                        OR subheadingL3 IN ({placeholders}))
+        """),
+        params,
+    ).fetchall()
+
     by_key = components["by_key"]
 
-    for row in rows:
-        src_key = (row[4], row[5] or None, row[6] or None, row[7] or None)
-        tgt_key = (row[8], row[9] or None, row[10] or None, row[11] or None)
+    def _resolve_conn_key(src_canon, src_os, src_hyp, src_stor,
+                          tgt_canon, tgt_os, tgt_hyp, tgt_stor,
+                          port, protocol):
+        src_canon = _SYNONYM_CANONICAL.get(src_canon, src_canon) if src_canon else src_canon
+        tgt_canon = _SYNONYM_CANONICAL.get(tgt_canon, tgt_canon) if tgt_canon else tgt_canon
+        src_key = (src_canon, src_os or None, src_hyp or None, src_stor or None)
+        tgt_key = (tgt_canon, tgt_os or None, tgt_hyp or None, tgt_stor or None)
         src_id = by_key.get(src_key)
         tgt_id = by_key.get(tgt_key)
         if src_id is not None and tgt_id is not None:
-            excluded.add((src_id, tgt_id, row[2], row[3]))
+            return (src_id, tgt_id, port, protocol)
+        return None
 
-    log.info("Exclusion filter: %d connection keys from %d enriched rows", len(excluded), len(rows))
+    # Build retained set — connections that exist outside excluded subsections
+    retained: set[tuple] = set()
+    for row in retained_rows:
+        key = _resolve_conn_key(row[0], row[1], row[2], row[3],
+                                row[4], row[5], row[6], row[7],
+                                row[8], row[9])
+        if key:
+            retained.add(key)
+
+    # Build excluded set, minus anything that also appears in retained sections
+    excluded: set[tuple] = set()
+    for row in rows:
+        key = _resolve_conn_key(row[4], row[5], row[6], row[7],
+                                row[8], row[9], row[10], row[11],
+                                row[2], row[3])
+        if key and key not in retained:
+            excluded.add(key)
+
+    log.info("Exclusion filter: %d connection keys from %d enriched rows (%d retained elsewhere)",
+             len(excluded), len(rows), len(retained))
     return excluded
 
 
@@ -765,16 +804,23 @@ def _resolve_service(
     # Priority 3: enrichment lookup (service name → canonical + qualifiers → component key)
     if service_name in enrichment_lookup:
         canonical, os_val, hyp, storage = enrichment_lookup[service_name]
+        canonical = _SYNONYM_CANONICAL.get(canonical, canonical)
         key = (canonical, os_val, hyp, storage)
         if key in components["by_key"]:
             return _expand_synonyms([components["by_key"][key]], components)
 
     # Priority 4: canonical name match — prefer fully-generic component
-    if lower in components["by_canonical"]:
-        generic_key = (lower, None, None, None)
-        if generic_key in components["by_key"]:
-            return _expand_synonyms([components["by_key"][generic_key]], components)
-        return _expand_synonyms(components["by_canonical"][lower], components)
+    # Also check synonym variants so "esxi server" finds "esxi host" components.
+    candidates = [lower]
+    synonym_of = _SYNONYM_CANONICAL.get(lower)
+    if synonym_of and synonym_of != lower:
+        candidates.append(synonym_of)
+    for candidate in candidates:
+        if candidate in components["by_canonical"]:
+            generic_key = (candidate, None, None, None)
+            if generic_key in components["by_key"]:
+                return _expand_synonyms([components["by_key"][generic_key]], components)
+            return _expand_synonyms(components["by_canonical"][candidate], components)
 
     # Priority 5: strip parenthetical suffix → retry canonical match
     stripped = _strip_parenthetical(service_name).lower()
@@ -787,6 +833,7 @@ def _resolve_service(
     # Priority 6: case-insensitive enrichment lookup
     if lower in enrichment_lookup_lower:
         canonical, os_val, hyp, storage = enrichment_lookup_lower[lower]
+        canonical = _SYNONYM_CANONICAL.get(canonical, canonical)
         key = (canonical, os_val, hyp, storage)
         if key in components["by_key"]:
             return _expand_synonyms([components["by_key"][key]], components)

--- a/ports_server.py
+++ b/ports_server.py
@@ -941,6 +941,24 @@ def _split_protocols(protocol: str) -> list[str]:
     return [p for p in parts if p in ("TCP", "UDP")]
 
 
+def _normalize_port_entries(ports: set[str]) -> list[str]:
+    """Split compound port strings and normalize formatting.
+
+    E.g. {"6162, 2500 to 3300", "443"} → ["443", "2500-3300", "6162"]
+    """
+    result: set[str] = set()
+    for p in ports:
+        # Split on comma
+        for part in p.split(","):
+            part = part.strip()
+            if not part:
+                continue
+            # Normalize "X to Y" → "X-Y"
+            part = re.sub(r"(\d+)\s+to\s+(\d+)", r"\1-\2", part)
+            result.add(part)
+    return sorted(result)
+
+
 _CSV_COLUMNS = ["Source Server", "Target Server", "Source Service", "Target Service",
                 "Port", "Protocol", "Description"]
 
@@ -1014,14 +1032,15 @@ def _build_app_import_server(
 ) -> AppImportServer:
     """Build the app-import server response for a single server.
 
-    Only includes outbound entries (where this server hosts the source
-    component). The frontend derives inbound by cross-referencing all
-    servers' mappedPorts where targetServerName matches this server.
+    Includes outbound entries (where this server hosts the source
+    component) and computes inbound aggregates (where this server
+    hosts the target component and the source belongs to another server).
     """
     server_id = str(uuid.uuid4())
     mapped_ports: list[AppImportMappedPort] = []
     seen: set[tuple] = set()
 
+    # --- Outbound: this server hosts the source component ---
     for conn_row in connections:
         src_id = conn_row["source_component_id"]
         tgt_id = conn_row["target_component_id"]
@@ -1033,13 +1052,10 @@ def _build_app_import_server(
         source_canonical = all_components[src_id]["canonical"]
         target_canonical = all_components[tgt_id]["canonical"]
 
-        # Outbound only: this server hosts the source component
         if src_id in server_components:
             for peer_server in component_to_servers.get(tgt_id, []):
                 if peer_server == server_name and not include_loopback:
                     continue
-                # Use synonym-normalized canonical names for dedup so
-                # "ESXi server" / "ESXi host" collapse to one entry.
                 dedup_src = _SYNONYM_CANONICAL.get(source_canonical, source_canonical)
                 dedup_tgt = _SYNONYM_CANONICAL.get(target_canonical, target_canonical)
                 dedup_key = (server_name, peer_server, dedup_src,
@@ -1054,28 +1070,86 @@ def _build_app_import_server(
                         targetService=target_service,
                         description=description,
                         product=product,
-                        port=port, protocol=protocol,
+                        port=re.sub(r"(\d+)\s+to\s+(\d+)", r"\1-\2", port),
+                        protocol=protocol.upper(),
                     ))
 
-    # Aggregate outbound protocol lists
+    # --- Outbound aggregates ---
     outbound_tcp: set[str] = set()
     outbound_udp: set[str] = set()
-    outbound_by_sp: dict[tuple, set] = defaultdict(set)
+    outbound_by_sp: dict[tuple, set[str]] = defaultdict(set)
+    # Track target service per (serverName, port, protocol) for the service field
+    outbound_service: dict[tuple, str] = {}
 
     for mp in mapped_ports:
+        individual_ports = _normalize_port_entries({mp.port})
         for proto in _split_protocols(mp.protocol):
-            if proto == "TCP":
-                outbound_tcp.add(mp.port)
-            elif proto == "UDP":
-                outbound_udp.add(mp.port)
-            outbound_by_sp[(mp.targetServerName, proto)].add(mp.port)
+            for ip in individual_ports:
+                if proto == "TCP":
+                    outbound_tcp.add(ip)
+                elif proto == "UDP":
+                    outbound_udp.add(ip)
+                outbound_by_sp[(mp.targetServerName, proto)].add(ip)
+                outbound_service[(mp.targetServerName, proto, ip)] = mp.targetService
 
     mapped_by_protocol = []
     idx = 0
     for (server, proto), ports in sorted(outbound_by_sp.items()):
         for port in sorted(ports):
+            service = outbound_service.get((server, proto, port), "")
             mapped_by_protocol.append(AppImportPortByProtocol(
-                index=idx, serverName=server, service="",
+                index=idx, serverName=server, service=service,
+                protocol=proto, port=port,
+            ))
+            idx += 1
+
+    # --- Inbound: this server hosts the target component ---
+    inbound_tcp: set[str] = set()
+    inbound_udp: set[str] = set()
+    inbound_by_sp: dict[tuple, set[str]] = defaultdict(set)
+    inbound_service: dict[tuple, str] = {}
+    inbound_seen: set[tuple] = set()
+
+    for conn_row in connections:
+        src_id = conn_row["source_component_id"]
+        tgt_id = conn_row["target_component_id"]
+        port = conn_row["port"]
+        protocol = conn_row["protocol"]
+
+        if tgt_id not in server_components:
+            continue
+
+        for peer_server in component_to_servers.get(src_id, []):
+            if peer_server == server_name and not include_loopback:
+                continue
+
+            source_canonical = all_components[src_id]["canonical"]
+            target_canonical = all_components[tgt_id]["canonical"]
+            dedup_src = _SYNONYM_CANONICAL.get(source_canonical, source_canonical)
+            dedup_tgt = _SYNONYM_CANONICAL.get(target_canonical, target_canonical)
+            dedup_key = (peer_server, server_name, dedup_src, dedup_tgt, port, protocol)
+            if dedup_key in inbound_seen:
+                continue
+            inbound_seen.add(dedup_key)
+
+            source_service = all_components[src_id]["original_name"]
+            individual_ports = _normalize_port_entries({port})
+            for proto in _split_protocols(protocol):
+                for ip in individual_ports:
+                    if proto == "TCP":
+                        inbound_tcp.add(ip)
+                    elif proto == "UDP":
+                        inbound_udp.add(ip)
+                    inbound_by_sp[(peer_server, proto)].add(ip)
+                    inbound_service[(peer_server, proto, ip)] = source_service
+
+    mapped_by_protocol_inbound = []
+    idx = 0
+    for (server, proto), ports in sorted(inbound_by_sp.items()):
+        for port in sorted(ports):
+            service = inbound_service.get((server, proto, port), "")
+            mapped_by_protocol_inbound.append(AppImportPortByProtocol(
+                index=idx, serverName=server, service=service,
                 protocol=proto, port=port,
             ))
             idx += 1
@@ -1087,15 +1161,15 @@ def _build_app_import_server(
         id=server_id,
         sourceServer=server_name,
         totalMappedPorts=len(mapped_ports),
-        totalMappedInboundPorts=0,
+        totalMappedInboundPorts=len(inbound_seen),
         totalMappedServers=len(peer_servers),
         mappedPorts=mapped_ports,
-        allInboundPortsTcp=[],
-        allOutboundPortsTcp=sorted(outbound_tcp),
-        allInboundPortsUdp=[],
-        allOutboundPortsUdp=sorted(outbound_udp),
+        allInboundPortsTcp=_normalize_port_entries(inbound_tcp),
+        allOutboundPortsTcp=_normalize_port_entries(outbound_tcp),
+        allInboundPortsUdp=_normalize_port_entries(inbound_udp),
+        allOutboundPortsUdp=_normalize_port_entries(outbound_udp),
         mappedPortsByProtocol=mapped_by_protocol,
-        mappedPortsByProtocolInbound=[],
+        mappedPortsByProtocolInbound=mapped_by_protocol_inbound,
     )
 
 

--- a/synonyms.py
+++ b/synonyms.py
@@ -1,0 +1,22 @@
+"""Shared synonym definitions for canonical name normalization.
+
+Imported by both ports_server.py (runtime resolution) and
+graph_builder.py (graph build-time merge).
+"""
+
+# Each set groups canonical names that refer to the same logical component.
+# The alphabetically-first name in each set becomes the canonical representative.
+# All values must be lowercase.
+ROLE_SYNONYM_GROUPS: list[set[str]] = [
+    {"esxi server", "esxi host"},
+]
+
+# Derived lookups — built once at import time.
+SYNONYM_INDEX: dict[str, set[str]] = {}
+SYNONYM_CANONICAL: dict[str, str] = {}
+
+for _group in ROLE_SYNONYM_GROUPS:
+    _representative = min(_group)  # alphabetically first for stability
+    for _name in _group:
+        SYNONYM_INDEX[_name] = _group - {_name}
+        SYNONYM_CANONICAL[_name] = _representative


### PR DESCRIPTION
## Summary
- Add subsection/port exclusion filtering to topology and app-import endpoints (#24)
- Add service discovery endpoint `GET /products/{name}/services` (#25)
- Add fuzzy-match warnings for unresolved services (#26)
- Add CSV and markdown output formats (#28)
- Fix ESXi synonym merge at graph build time and runtime lookup
- Fix synonym resolution in service lookup priorities 3, 4, 6
- Fix subsection exclusion over-filtering (retain connections that also appear in non-excluded subsections)
- Fix app-import structure: populate inbound fields, normalize port strings, fill service metadata

## Test plan
- [x] `GET /products/VBR v13/services` returns canonical services with variants
- [x] POST app-import with `exclude_subsections: ["CDP Components"]` excludes CDP-only connections
- [x] POST app-import with typo service name returns fuzzy suggestions in warnings
- [x] POST topology with `?format=csv` / `?format=markdown` returns correct format
- [x] App-import JSON imports successfully into Magic Ports frontend
- [x] VBR Appliance shows 443 to ESXi Host and vCenter with CDP exclusion

🤖 Generated with [Claude Code](https://claude.com/claude-code)